### PR TITLE
Refactor/Modernize cmake vcpkg project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,6 @@ project(gltoys
     LANGUAGES CXX)
 
 
-#set(VCPKG_TARGET_TRIPLET x64-linux CACHE STRING "VCPKG Target Triplet to use")
 
 if(DEFINED ENV{VCPKG_ROOT})
     include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.28)
+
+project(gltoys 
+    VERSION 0.3.0
+    DESCRIPTION "OpenGL toys by 386dx25"
+    LANGUAGES CXX)
+
+
+#set(VCPKG_TARGET_TRIPLET x64-linux CACHE STRING "VCPKG Target Triplet to use")
+
+if(DEFINED ENV{VCPKG_ROOT})
+    include("$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake")
+elseif(EXISTS "${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+    include("${CMAKE_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake")
+else()
+    message(FATAL_ERROR "Vcpkg not found")
+endif()
+
+
+
+set(CMAKE_CXX_STANDARD 20)
+
+
+set(BUILD_GLTOYS_APPS true CACHE BOOL "Build gltoys applications.")
+set(BUILD_TOYLIB_TEST_APPS true CACHE BOOL "Build toylib test applications for development.")
+set(BUILD_SHARED_LIBRARY false CACHE BOOL "Buid shared library.")
+
+
+find_package(OpenGL REQUIRED)
+find_package(GLEW REQUIRED)
+find_package(glm REQUIRED)
+
+if (BUILD_GLTOYS_APPS)
+    find_package(glfw3 CONFIG REQUIRED)
+    find_package(imgui CONFIG REQUIRED)
+    add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GLEW)
+endif()
+
+
+add_subdirectory(source)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -25,5 +25,17 @@
                 "CXX": "g++-13"
             }
         }
+   ],
+   "buildPresets": [
+        {
+            "name": "Debug",
+            "configurePreset": "ninja-gcc13",
+            "configuration": "Debug"
+        },
+        {
+            "name": "Release",
+            "configurePreset": "ninja-gcc13",
+            "configuration": "Release"
+        }
    ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,29 @@
+{
+    "version" : 8,
+    "configurePresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build/${presetName}"
+        },
+        {
+            "name": "default",
+            "inherits": "base"
+        },
+        {
+            "name": "ninja",
+            "hidden": true,
+            "generator": "Ninja Multi-Config"
+        },
+        {
+            "name": "ninja-gcc13",
+            "inherits": [
+                "default",
+                "ninja"
+            ],
+            "environment": {
+                "CXX": "g++-13"
+            }
+        }
+   ]
+}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,31 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
-
-set(CMAKE_TOOLCHAIN_FILE "~/repos/vcpkg/scripts/buildsystems/vcpkg.cmake")
-set(VCPKG_TARGET_TRIPLET x64-linux CACHE STRING "VCPKG Target Triplet to use")
-
-project(gltoys 
-    VERSION 0.2
-    DESCRIPTION "OpenGL toys by 386dx25"
-    LANGUAGES CXX)
-
-set(CMAKE_CXX_STANDARD 20)
-
-set(BUILD_GLTOYS_APPS true CACHE BOOL "Build gltoys applications.")
-set(BUILD_TOYLIB_TEST_APPS true CACHE BOOL "Build toylib test applications for development.")
-set(BUILD_SHARED_LIBRARY false CACHE BOOL "Buid shared library.")
-
 include_directories(./)
-
-find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(glm REQUIRED)
-
-if (BUILD_GLTOYS_APPS)
-    find_package(glfw3 CONFIG REQUIRED)
-    find_package(imgui CONFIG REQUIRED)
-    add_compile_definitions(IMGUI_IMPL_OPENGL_LOADER_GLEW)
-endif()
-
 
 set(glutils-sources
   glutils/GLConfig.h
@@ -92,7 +65,6 @@ endif()
 target_link_libraries(toylib GLEW::GLEW ${OPENGL_LIBRARY})
 
 if (BUILD_GLTOYS_APPS)
-
     add_executable(toy-hello toy-hello.cpp ${imgui-impl-sources})
     target_link_libraries(toy-hello PRIVATE toylib imgui::imgui glfw)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "386dx25-gltoys",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "dependencies": [
     "glew",
     "glm",


### PR DESCRIPTION
- Move CMakeLists.txt and vcpkg.json to project root (as expected e.g. by vscode)
- Configure vcpkg toolchain via `VCPKG_ROOT` environment variable or warn if not present 
  (script lines taken from [here](https://www.susi.se/blog/2025/01/26/setting-up-a-new-c-project/))
- Add CMakePresets.json with Ninja Multi-Config generator
- Add buildPresets for convenient switching of Debug and Release in vscode for Ninja Multi-Config