### PR TITLE
Fix geometry normals

### DIFF
--- a/source/geometry/Icosahedron.cpp
+++ b/source/geometry/Icosahedron.cpp
@@ -10,14 +10,14 @@ void Icosahedron::add_face_subdivision(Face f, int levels)
     }
 
     // get vertices
-    vec3 v1 = get_vertex(f.vi[0]), v2 = get_vertex(f.vi[1]),
+    vec3 v1 = get_vertex(f.vi[0]), 
+         v2 = get_vertex(f.vi[1]),
          v3 = get_vertex(f.vi[2]);
 
     // new vertices
-    vec3 v12 = v1, v13 = v1, v23 = v2;
-    v12 += v2;
-    v13 += v3;
-    v23 += v3;
+    vec3 v12 = v1 + v2;
+    vec3 v13 = v1 + v3;
+    vec3 v23 = v2 + v3;
 
     // normalize such that the new vertices again lie on the unit sphere surface
     v12.normalize();
@@ -25,17 +25,14 @@ void Icosahedron::add_face_subdivision(Face f, int levels)
     v23.normalize();
 
     float const foo = (float)m_platonicConstantZ;
-    v12 *= foo;
-    v13 *= foo;
-    v23 *= foo;
 
     // corresponding indices
     int i1 = f.vi[0], i2 = f.vi[1], i3 = f.vi[2],
-        i12 = add_vertex_and_normal(v12, v12 / v12.magnitude()),
-        i13 = add_vertex_and_normal(v13, v13 / v13.magnitude()),
-        i23 = add_vertex_and_normal(v23, v23 / v23.magnitude());
+        i12 = add_vertex_and_normal(v12 * foo, v12),
+        i13 = add_vertex_and_normal(v13 * foo, v13),
+        i23 = add_vertex_and_normal(v23 * foo, v23);
 
-    // 4 new faces
+    // 4 new faces (in same orientation)
     add_face_subdivision(Face(i1, i12, i13), levels - 1);
     add_face_subdivision(Face(i12, i2, i23), levels - 1);
     add_face_subdivision(Face(i13, i23, i3), levels - 1);
@@ -57,14 +54,14 @@ void Icosahedron::create(int levels)
                       vec3(0, 1, -tao),  vec3(0, -1, -tao), vec3(tao, 0, 1),
                       vec3(-tao, 0, 1),  vec3(tao, 0, -1),  vec3(-tao, 0, -1)};
 
-    static int tindices[20][3] = {
+    static int tindices[20][3] = { // ccw winding
         {0, 1, 4},  {1, 9, 4},  {4, 9, 5},  {5, 9, 3},  {2, 3, 7},
         {3, 2, 5},  {7, 10, 2}, {0, 8, 10}, {0, 4, 8},  {8, 2, 10},
         {8, 4, 5},  {8, 5, 2},  {1, 0, 6},  {11, 1, 6}, {3, 9, 11},
         {6, 10, 7}, {3, 11, 7}, {11, 6, 7}, {6, 0, 10}, {9, 1, 11}};
 
     // exact memory calulation
-    int n = (int)(20.0 * pow(4.0, (double)levels));
+    int const n = (int)(20.0 * pow(4.0, (double)levels));
     reserve_vertices(n - 8);
     reserve_faces(n);
 

--- a/source/geometry/Icosahedron.cpp
+++ b/source/geometry/Icosahedron.cpp
@@ -41,6 +41,8 @@ void Icosahedron::add_face_subdivision(Face f, int levels)
 
 void Icosahedron::create(int levels)
 {
+    clear();
+
     if (levels < 0)
         levels = m_levels;
     else
@@ -79,4 +81,7 @@ void Icosahedron::create(int levels)
     {
         add_face_subdivision(Face(tindices[i]), levels);
     }
+
+    
+    unifyVertices();
 }

--- a/source/geometry/Icosahedron.h
+++ b/source/geometry/Icosahedron.h
@@ -8,9 +8,9 @@ class Icosahedron : public SimpleGeometry
   public:
     static constexpr double GoldenRatio = 1.6180339887498948482045;
 
-    Icosahedron() : SimpleGeometry() 
+    Icosahedron(int levels = 4) : SimpleGeometry() 
     {
-        create();
+        create(levels);
     };
 
     void setPlatonicConstants(double X, double Z)

--- a/source/geometry/Icosahedron.h
+++ b/source/geometry/Icosahedron.h
@@ -8,7 +8,7 @@ class Icosahedron : public SimpleGeometry
   public:
     static constexpr double GoldenRatio = 1.6180339887498948482045;
 
-    Icosahedron(int levels = 4) : SimpleGeometry() 
+    Icosahedron(int levels = 3) : SimpleGeometry() 
     {
         create(levels);
     };
@@ -31,7 +31,7 @@ class Icosahedron : public SimpleGeometry
 
     /// Create an Icosahedron model where each face is subdivided level times
     /// In the limit the subdivision surface is a sphere.
-    void create(int level = -1);
+    void create(int level = -1) override;
 
   protected:
     /// Recursive face subdivision routine

--- a/source/geometry/Penrose.cpp
+++ b/source/geometry/Penrose.cpp
@@ -110,6 +110,8 @@ void Penrose::add_face_subdivision(SimpleGeometry::Face f, int type, int levels)
 
 void Penrose::create(int levels)
 {
+    clear();
+
     if (levels < 0)
         levels = m_levels;
     else

--- a/source/geometry/SimpleGeometry.cpp
+++ b/source/geometry/SimpleGeometry.cpp
@@ -1,7 +1,9 @@
 #include <geometry/SimpleGeometry.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio> // fprintf, fopen, FILE
+#include <stdexcept>
 
 SimpleGeometry::Face::Face() { vi[0] = vi[1] = vi[2] = 0; }
 
@@ -126,4 +128,186 @@ bool SimpleGeometry::writeOBJ(const char *filename) const
 
     fclose(f);
     return true;
+}
+
+void SimpleGeometry::computeFaceNormalsAndAdjacency()
+{
+    faceNormals.clear();
+    facesAdjacentToVertex.clear();
+
+    faceNormals.resize(num_faces()*3);
+
+    auto setFaceNormal = [this](int fi, vec3 const& n)
+    {
+        auto i = 3*fi;
+        faceNormals[i+0] = n.x;
+        faceNormals[i+1] = n.y;
+        faceNormals[i+2] = n.z;
+    };
+
+    auto cross = [](vec3 const& a, vec3 const& b)
+    {
+        return a.cross(b);
+    };
+
+    for(int fi=0; fi < num_faces(); ++fi)
+    {
+        Face face = get_face(fi);
+        facesAdjacentToVertex[face.vi[0]].insert(fi);
+        facesAdjacentToVertex[face.vi[1]].insert(fi);
+        facesAdjacentToVertex[face.vi[2]].insert(fi);
+
+        // Assume consistent orientation of face indices
+        vec3 v0 = get_vertex(face.vi[0]);
+        vec3 v1 = get_vertex(face.vi[1]);
+        vec3 v2 = get_vertex(face.vi[2]);
+        setFaceNormal(fi, cross(v1 - v0, v2 - v0).normalized());
+    }
+}
+
+void SimpleGeometry::recomputeVertexNormals()
+{
+    computeFaceNormalsAndAdjacency();
+
+    auto getFaceNormal = [this](int fi) -> vec3
+    {
+        auto const i = 3*fi;
+        return { faceNormals[i], faceNormals[i+1], faceNormals[i+2] };
+    };
+
+    for(int vi=0; vi < num_vertices(); ++vi)
+    {
+        if(facesAdjacentToVertex.contains(vi))
+        {
+            vec3 n(0,0,0);
+
+            for(int fi : facesAdjacentToVertex[vi])
+            {
+                n += getFaceNormal(fi);
+            }
+            n.normalize();
+
+            set_normal(vi, n);
+        }
+        else
+        {
+            throw std::logic_error("Encountered singular vertex");
+        }
+    }
+}
+
+class Matrix
+{
+public:
+    Matrix(std::size_t rows, std::size_t cols)
+    : rows(rows), cols(cols), data(new float[rows*cols]) {}
+    ~Matrix() { delete [] data; }
+    float& operator () (std::size_t row, std::size_t col) 
+    { return data[row*cols+col]; }
+    float const& operator () (std::size_t row, std::size_t col) const 
+    { return data[row*cols+col]; }
+private:
+    std::size_t rows = 0;
+    std::size_t cols = 0;
+    float* data = nullptr;
+};
+
+void SimpleGeometry::unifyVertices()
+{
+    std::size_t n = static_cast<std::size_t>(num_vertices());
+    Matrix D(n, n);
+    for(auto i=0; i < n; ++i)
+    {
+        D(i,i) = 0.f;
+
+        for(auto j=i+1; j < n; ++j)
+        {
+            D(i,j) = (get_vertex(j) - get_vertex(i)).magnitude();
+            D(j,i) = D(i,j);
+        }
+    }
+    
+    float const threshold = 1e-5f;
+
+    std::vector<std::size_t> mapSameVertexToSmallestIndex(n);
+    for(auto i=0; i < n; ++i) mapSameVertexToSmallestIndex[i] = i;
+
+    for(auto i=0; i < n; ++i)
+    {
+        for(auto j=0; j < n; ++j)
+        {
+            if(i!=j)
+            {
+                if(D(i,j) < threshold)
+                {
+                    mapSameVertexToSmallestIndex[j] = std::min<std::size_t>(i, mapSameVertexToSmallestIndex[j]);
+                }
+            }
+        }
+    }
+
+    SimpleGeometry unifiedGeometry;
+    std::vector<std::size_t> newVertexIndex(n);
+    for(auto i=0; i < n; ++i)
+    {
+        if(mapSameVertexToSmallestIndex[i] == i)
+        {
+            newVertexIndex[i] = unifiedGeometry.add_vertex_and_normal(get_vertex(i), get_normal(i));
+        }
+        else if(mapSameVertexToSmallestIndex[i] < i)
+        {
+            newVertexIndex[i] = newVertexIndex[mapSameVertexToSmallestIndex[i]];
+        }
+        else
+        {
+            throw std::logic_error("Unifying vertices failed");
+        }
+    }
+
+    // Update faces
+    std::size_t degeneratedTriangles = 0;
+    int highestVertexIndex = -1;
+    for(auto fi=0; fi < num_faces(); ++fi)
+    {
+        auto const f = get_face(fi);
+        Face f_new( newVertexIndex[f.vi[0]], newVertexIndex[f.vi[1]], newVertexIndex[f.vi[2]] );
+        if(f_new.vi[0] == f_new.vi[1] || f_new.vi[0] == f_new.vi[2] || f_new.vi[1] == f_new.vi[2])
+        {
+            degeneratedTriangles++;
+        }
+        else
+        {
+            unifiedGeometry.add_face(f_new);
+        }
+
+        highestVertexIndex = std::max(std::max(f_new.vi[0], f_new.vi[1]), f_new.vi[2]);
+    }
+
+    if(highestVertexIndex > unifiedGeometry.num_vertices())
+    {
+        std::cout << "Highest new vertex index " << highestVertexIndex << " is larger than number of unified vertices " << unifiedGeometry.num_vertices() << "\n";
+        throw std::logic_error("Unifying faces failed");
+    }
+    
+
+    if(degeneratedTriangles>0)
+    {
+        std::cout << "Removed " << degeneratedTriangles << " degenerated triangles\n";
+    }
+    
+    newVertexIndex.clear();
+
+    if(unifiedGeometry.num_vertices() < num_vertices() && unifiedGeometry.num_faces() <= num_faces())
+    {
+        std::cout << "Unified " << num_vertices() << " vertices to " << unifiedGeometry.num_vertices() << "\n";
+        std::cout << "Unified " << num_faces() << " faces to " << unifiedGeometry.num_faces() << "\n";
+
+        m_vdata = std::move(unifiedGeometry.m_vdata);
+        m_ndata = std::move(unifiedGeometry.m_ndata);
+        m_fdata = std::move(unifiedGeometry.m_fdata);
+    }
+    else
+    {
+        std::cout << "No vertices to unify\n";
+    }    
 }

--- a/source/geometry/SimpleGeometry.h
+++ b/source/geometry/SimpleGeometry.h
@@ -14,7 +14,11 @@ class SimpleGeometry
     SimpleGeometry() = default;
     virtual ~SimpleGeometry() = default;
 
-    virtual void create(int param) {}
+    // Re-create mesh geometry with different number of vertices
+    virtual void create(int param=-1) {}
+
+    // Update vertex positions based on (changed) parameters
+    virtual void update() {};
 
     virtual void setLevels(int levels) {}
     virtual int getLevels() const { return 0; }

--- a/source/geometry/SimpleGeometry.h
+++ b/source/geometry/SimpleGeometry.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "Vector.h" // vec3
+#include <map>
+#include <set>
 #include <vector>
 
 /// Indexed face set in linear tightly packed vertex/index buffers
@@ -10,7 +12,7 @@ class SimpleGeometry
 {
   public:
     SimpleGeometry() = default;
-    virtual ~SimpleGeometry() {}
+    virtual ~SimpleGeometry() = default;
 
     virtual void create(int param) {}
 
@@ -37,12 +39,19 @@ class SimpleGeometry
     bool writeOBJ(const char *filename) const;
 
     /// Return one-ring vertex indices for vertex i (expensive!)
-    void get_one_ring(int i, std::vector<int> &N) const;
+    //void get_one_ring(int i, std::vector<int> &N) const;
 
     /// Create mesh dual, written as new geometry to res
-    void make_dual(SimpleGeometry &res) const;
+    //void make_dual(SimpleGeometry &res) const;
+
+    void recomputeVertexNormals();
+
+    void unifyVertices();
 
   protected:
+    void computeFaceNormalsAndAdjacency();
+
+
     /// Reserve memory for vertices
     void reserve_vertices(int n);
     /// Reserve memory for face indices
@@ -79,4 +88,8 @@ class SimpleGeometry
     std::vector<float> m_vdata;
     std::vector<float> m_ndata; // vertex normals
     std::vector<unsigned> m_fdata;
+
+    std::vector<float> faceNormals;
+
+    std::map<int, std::set<int>> facesAdjacentToVertex;
 };

--- a/source/geometry/SphericalHarmonics.cpp
+++ b/source/geometry/SphericalHarmonics.cpp
@@ -67,13 +67,11 @@ void SphericalHarmonics::update()
         }
     }
 
-    // TODO: Update normals!
+    recomputeVertexNormals();
 }
 
 void SphericalHarmonics::create(int level)
 {
-    clear();
-
     // Sample vertices on sphere via an subdivided icosahedron
     Icosahedron::create(level);
 

--- a/source/geometry/SphericalHarmonics.h
+++ b/source/geometry/SphericalHarmonics.h
@@ -6,8 +6,9 @@ class SphericalHarmonics : public Icosahedron
   public:
     SphericalHarmonics();
     
-    void create(int level = -1);
-    void update();
+    void create(int level = -1) override;
+    void update() override;
+    
     void setLM(int l, int m);
     int getL() const { return m_l; }
     int getM() const { return m_m; }

--- a/source/geometry/SphericalHarmonicsFunction.cpp
+++ b/source/geometry/SphericalHarmonicsFunction.cpp
@@ -15,18 +15,22 @@ std::tuple<double, double> polar(const vec3 &v)
     return {std::acos(v.z / l), std::atan2(v.y / l, v.x / l)};
 }
 
+SphericalHarmonicsFunction::SphericalHarmonicsFunction(int order)
+ : m_order(order)
+{
+    create();
+}
+
 void SphericalHarmonicsFunction::create(int level)
 {
-    clear();
-
     // Sample vertices on sphere via an subdivided icosahedron
-    Icosahedron::create(level);
+    Icosahedron::create(level); // -> invokes clear()
+
+    // Compute SH basis (expensive; depends on order and vertices)
+    createBasis();
 
     // Cache vertices
-    m_vcache = vbuffer();
-
-    // Compute SH basis (expensive, depending on order)
-    createBasis();
+    nonDisplacedVertices = vbuffer();
 }
 
 void SphericalHarmonicsFunction::resetCoefficients()
@@ -92,6 +96,8 @@ vec3 fromPolar(double theta, double phi)
 void SphericalHarmonicsFunction::update()
 {
     constexpr bool Debug = false;
+    constexpr bool DoComputeNormalFromGradient = false;
+
 
     for (int i = 0; i < num_vertices(); ++i)
     {
@@ -105,35 +111,44 @@ void SphericalHarmonicsFunction::update()
         }
 
         // Displace vertex
-        vec3 v(m_vcache[i * 3], m_vcache[i * 3 + 1],
-               m_vcache[i * 3 + 2]); // get_vertex( i );
+        vec3 v(nonDisplacedVertices[i * 3], nonDisplacedVertices[i * 3 + 1],
+               nonDisplacedVertices[i * 3 + 2]); // get_vertex( i );
         v.normalize();               // Project onto unit sphere (sanity)
         set_vertex(i, v * (float)s.r);
 
-        // Normal from gradient
-        auto const [theta, phi] = polar(v);
-
-        if constexpr (Debug)
+       
+        if constexpr (DoComputeNormalFromGradient)
         {
-            std::printf("vertex %04d: theta=%8.7fpi, phi=%8.7fpi\n", i,
-                        theta / M_PI, phi / M_PI);
-        }
+            // Normal from gradient
+            auto const [theta, phi] = polar(v);
 
-        vec3 n = fromPolar(theta - s.dtheta, phi - s.dphi);
-        n.normalize();
-
-        // Handle zero angles
-        constexpr double eps = 0.1;
-        if (abs(theta / M_PI) < eps && abs(phi / M_PI) < eps)
-        {
             if constexpr (Debug)
             {
-                std::printf("*** Encountered zero angles at vertex %d\n", i);
+                std::printf("vertex %04d: theta=%8.7fpi, phi=%8.7fpi\n", i,
+                            theta / M_PI, phi / M_PI);
             }
-            n = vec3(0.f, 0.f, 1.f);
-        }
 
-        set_normal(i, n);
+            vec3 n = fromPolar(theta - s.dtheta, phi - s.dphi);
+            n.normalize();
+
+            // Handle zero angles
+            constexpr double eps = 0.1;
+            if (abs(theta / M_PI) < eps && abs(phi / M_PI) < eps)
+            {
+                if constexpr (Debug)
+                {
+                    std::printf("*** Encountered zero angles at vertex %d\n", i);
+                }
+                n = vec3(0.f, 0.f, 1.f);
+            }
+
+            set_normal(i, n);
+        }
+    }
+
+    if constexpr (!DoComputeNormalFromGradient)
+    {        
+        recomputeVertexNormals();
     }
 }
 

--- a/source/geometry/SphericalHarmonicsFunction.h
+++ b/source/geometry/SphericalHarmonicsFunction.h
@@ -4,10 +4,10 @@
 class SphericalHarmonicsFunction : public Icosahedron
 {
   public:
-    SphericalHarmonicsFunction(int order = 10) : m_order(order) { create(); }
+    SphericalHarmonicsFunction(int order = 10);
 
-    void create(int level = -1);
-    void update();
+    void create(int level = -1) override;
+    void update() override;
 
     void resetCoefficients();
     void randomizeCoefficients();
@@ -30,5 +30,5 @@ class SphericalHarmonicsFunction : public Icosahedron
     std::vector<float> m_radius;         // Scaling factor
     std::vector<float> m_coeffs;         // SH coefficients
     int m_order;                         // number of SH bands
-    std::vector<float> m_vcache;         // vertex cache for icosahedron
+    std::vector<float> nonDisplacedVertices;         // vertex cache for icosahedron
 };

--- a/source/geometry/Superquadric.h
+++ b/source/geometry/Superquadric.h
@@ -29,7 +29,9 @@ public:
         create();
     };
 
-    void create(int unused = -1);
+    void create(int unused = -1) override;
+
+    void update() override { create(); }
 
     Mode getMode() const { return mode; }
 

--- a/source/glutils/MeshShader.h
+++ b/source/glutils/MeshShader.h
@@ -142,8 +142,12 @@ uniform vec4 uniform_color;
 void main() 
 {
 #ifdef HAS_ATTRIBUTE_NORMAL
-    //float diffuse = shading ? abs(dot(normalize(normal),normalize(position-vec3(0,0,-5)))) : 1.0;
+  #define DUAL_SIDED_SHADING
+  #ifdef DUAL_SIDED_SHADING
+    float diffuse = shading ? abs(dot(normalize(normal),normalize(position-vec3(0,0,-5)))) : 1.0;
+  #else
     float diffuse = shading ? max(0.0,dot(normalize(normal),normalize(position-vec3(0,0,-5)))) : 1.0;
+  #endif
 #else
     float diffuse = 1.0;
 #endif

--- a/source/toy-geometry-cli.cpp
+++ b/source/toy-geometry-cli.cpp
@@ -4,10 +4,15 @@
 int main(int argc, char* argv[])
 {
     std::cout << "Write icosahedron...\n";
-    Icosahedron icosahedron;
-    icosahedron.create(1);
-    icosahedron.writeOBJ("icosahedron-1.obj");
+    
+    Icosahedron icosahedron(1);
+    icosahedron.writeOBJ("icosahedron.obj");
 
+    icosahedron.unifyVertices();
+    icosahedron.recomputeVertexNormals();
+    icosahedron.writeOBJ("icosahedron-recomputed-normals.obj");
+
+/*
     std::cout << "Write penrose...\n";
     Penrose penrose;
     penrose.create();
@@ -27,6 +32,6 @@ int main(int argc, char* argv[])
     SphericalHarmonicsFunction shf;
     shf.create();
     shf.writeOBJ("shf.obj");
-
+*/
     return 0;
 }

--- a/source/toy-geometry-cli.cpp
+++ b/source/toy-geometry-cli.cpp
@@ -3,6 +3,7 @@
 
 int main(int argc, char* argv[])
 {
+/*
     std::cout << "Write icosahedron...\n";
     
     Icosahedron icosahedron(1);
@@ -11,7 +12,7 @@ int main(int argc, char* argv[])
     icosahedron.unifyVertices();
     icosahedron.recomputeVertexNormals();
     icosahedron.writeOBJ("icosahedron-recomputed-normals.obj");
-
+*/
 /*
     std::cout << "Write penrose...\n";
     Penrose penrose;
@@ -27,11 +28,12 @@ int main(int argc, char* argv[])
     SphericalHarmonics sh;
     sh.create();
     sh.writeOBJ("sh.obj");
-
+*/
     std::cout << "Write SphericalHarmonicsFunction...\n";
     SphericalHarmonicsFunction shf;
-    shf.create();
+    shf.randomizeCoefficients();    
+    shf.update();
     shf.writeOBJ("shf.obj");
-*/
+
     return 0;
 }

--- a/source/toy-geometry.cpp
+++ b/source/toy-geometry.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <fstream>
+#include <optional>
 #include <ranges>
 #include <span>
 
@@ -67,8 +68,6 @@ public:
 
     void update()
     {
-        geometry->recomputeVertexNormals();
-
         meshBuffer = std::make_shared<MeshBuffer>();
         copySimpleGeometryToMeshBuffer(*geometry, *meshBuffer);
         glmesh.setMeshBuffer(meshBuffer);
@@ -116,14 +115,23 @@ int main(int argc, char* argv[])
 
     // -- Scenes
 
-    int const DefaultSubdivisionLevels = 4;
+    int const DefaultSubdivisionLevels = 3;
+
+    // Initialize specific scenes
+    auto randomHarmonic = std::make_shared<SphericalHarmonicsFunction>();
+    randomHarmonic->randomizeCoefficients();
+    randomHarmonic->update();
+
+    auto tensorGlyph = std::make_shared<Superquadric>(Superquadric::Mode::TensorGlyph);
+    tensorGlyph->setParameters(Superquadric::TensorParameters{ 0.0, 0.25, 1.5 });
+    tensorGlyph->update();
 
     std::vector const scenes = { 
         std::make_shared<GeometryScene>("Icosahedron", std::make_shared<Icosahedron>()),
         std::make_shared<GeometryScene>("Superquadric", std::make_shared<Superquadric>()),
-        std::make_shared<GeometryScene>("Tensor glyph", std::make_shared<Superquadric>(Superquadric::Mode::TensorGlyph)),
+        std::make_shared<GeometryScene>("Tensor glyph", tensorGlyph),
         std::make_shared<GeometryScene>("Spherical Harmonics", std::make_shared<SphericalHarmonics>()),
-        std::make_shared<GeometryScene>("Random Harmonic", std::make_shared<SphericalHarmonicsFunction>()),
+        std::make_shared<GeometryScene>("Random Harmonic", randomHarmonic),
         std::make_shared<GeometryScene>("Penrose Tiling", std::make_shared<Penrose>())
     };
 
@@ -182,9 +190,41 @@ int main(int argc, char* argv[])
         float t = 0.f;
     } globals;
 
+
+    bool sceneNeedsUpdate = false;
+    std::optional<int> newLevel;
+
     while (app.running())
     {
         GeometryScene& scene = *scenes[globals.sceneIndex % scenes.size()].get();
+        
+        if(sceneNeedsUpdate)
+        {
+            auto& geometry = *scene.getSimpleGeometry();
+            if(newLevel.has_value())
+            {
+                geometry.create(newLevel.value() == 0 ? DefaultSubdivisionLevels : std::max(geometry.getLevels() + newLevel.value(), 0));
+
+                // Update displacement meshes
+                if(auto sphericalHarmonics = dynamic_cast<SphericalHarmonics*>(scene.getSimpleGeometry()))
+                {
+                    sphericalHarmonics->update();
+                }
+                else if(auto sphericalHarmonicsFunction = dynamic_cast<SphericalHarmonicsFunction*>(scene.getSimpleGeometry()))
+                {
+                    sphericalHarmonicsFunction->update();
+                }
+            }
+            else
+            {
+                geometry.update();
+            }
+
+            scene.update();
+
+            sceneNeedsUpdate = false;
+            newLevel.reset();
+        }
 
         app.beginFrame();
         GL::clearGLError("main - begin of main loop");
@@ -216,13 +256,14 @@ int main(int argc, char* argv[])
                 globals.sceneIndex = selected;
             }
 
-      
             auto fuzzy_equal = [](float a, double b)
             {
                 return std::fabs(a - gsl::narrow_cast<float>(b)) < 1e-6;
             };
 
             ImGui::SeparatorText("Scene specific parameters");
+
+          #if 0 // Disable Icosahedron glitch UI until update/create issue is fixed
             if(auto icosahedron = dynamic_cast<Icosahedron*>(scene.getSimpleGeometry()))
             {
                 float x = globals.animate ? globals.t : icosahedron->getPlatonicConstantsX();
@@ -240,12 +281,11 @@ int main(int argc, char* argv[])
                 || !fuzzy_equal(x, icosahedron->getPlatonicConstantsX()) 
                 || !fuzzy_equal(z, icosahedron->getPlatonicConstantsZ()) )
                 {
-                    icosahedron->clear();
                     icosahedron->setPlatonicConstants(x, z);
-                    icosahedron->create();
-                    scene.update();
+                    sceneNeedsUpdate = true;
                 }
             }
+          #endif
             
             if(auto superquadric = dynamic_cast<Superquadric*>(scene.getSimpleGeometry()))
             {
@@ -265,10 +305,8 @@ int main(int argc, char* argv[])
                     if(!fuzzy_equal(alpha, superquadric->getAlpha()) 
                     || !fuzzy_equal(beta, superquadric->getBeta()))
                     {
-                        superquadric->clear();
                         superquadric->setQuadric(alpha, beta);
-                        superquadric->create();
-                        scene.update();
+                        sceneNeedsUpdate = true;
                     }
                 }
                 else if(superquadric->getMode() == Superquadric::Mode::TensorGlyph)
@@ -292,10 +330,8 @@ int main(int argc, char* argv[])
                     || !fuzzy_equal(cl, superquadric->getTensorParameters().linearity)
                     || !fuzzy_equal(gamma, superquadric->getTensorParameters().sharpness))
                     {
-                        superquadric->clear();
                         superquadric->setParameters({.planarity = cp, .linearity = cl, .sharpness = gamma});
-                        superquadric->create();
-                        scene.update();
+                        sceneNeedsUpdate = true;
                     }
                 }
             }
@@ -315,10 +351,8 @@ int main(int argc, char* argv[])
 
                 if(L != sphericalHarmonics->getL() || M != sphericalHarmonics->getM())
                 {
-                    sphericalHarmonics->clear();
                     sphericalHarmonics->setLM(L, M);
-                    sphericalHarmonics->create();
-                    scene.update();
+                    sceneNeedsUpdate = true;
                 }
             }
 
@@ -345,18 +379,15 @@ int main(int argc, char* argv[])
 
                 if(dirty)
                 {
-                    sphericalHarmonicsFunction->update();
-                    scene.update();
+                    sceneNeedsUpdate = true; // but no create() call needed!
                 }
             }
 
             auto changeLevel = [&](int levelChange)
             {
-                auto& geometry = *scene.getSimpleGeometry();
-                geometry.clear();
-                geometry.create(levelChange == 0 ? DefaultSubdivisionLevels : std::max(geometry.getLevels() + levelChange, 0)); 
-                scene.update();
-            };
+                newLevel = levelChange;
+                sceneNeedsUpdate = true;
+            };            
             
             ImGui::SeparatorText("Subdivision levels (if applicable)");
             ImGui::Text(std::to_string(scene.getSimpleGeometry()->getLevels()).c_str());

--- a/source/toy-geometry.cpp
+++ b/source/toy-geometry.cpp
@@ -67,6 +67,8 @@ public:
 
     void update()
     {
+        geometry->recomputeVertexNormals();
+
         meshBuffer = std::make_shared<MeshBuffer>();
         copySimpleGeometryToMeshBuffer(*geometry, *meshBuffer);
         glmesh.setMeshBuffer(meshBuffer);

--- a/source/toy-geometry.cpp
+++ b/source/toy-geometry.cpp
@@ -193,6 +193,7 @@ int main(int argc, char* argv[])
 
     bool sceneNeedsUpdate = false;
     std::optional<int> newLevel;
+    bool icosahedronGlitchParametersChanged = false;
 
     while (app.running())
     {
@@ -200,22 +201,25 @@ int main(int argc, char* argv[])
         
         if(sceneNeedsUpdate)
         {
+            // Some geometries need an additional update() call even after create(), e.g. to update displacement mesh
+            bool const additionalUpdateCallNeeded =                 
+                dynamic_cast<SphericalHarmonics*>(scene.getSimpleGeometry()) 
+                ||  dynamic_cast<SphericalHarmonicsFunction*>(scene.getSimpleGeometry());
+            
+            // For most geometries a create() call makes another update() call obsolete
+            bool const doUpdateCallSufficient = !newLevel.has_value() || additionalUpdateCallNeeded; 
+
             auto& geometry = *scene.getSimpleGeometry();
             if(newLevel.has_value())
             {
                 geometry.create(newLevel.value() == 0 ? DefaultSubdivisionLevels : std::max(geometry.getLevels() + newLevel.value(), 0));
-
-                // Update displacement meshes
-                if(auto sphericalHarmonics = dynamic_cast<SphericalHarmonics*>(scene.getSimpleGeometry()))
-                {
-                    sphericalHarmonics->update();
-                }
-                else if(auto sphericalHarmonicsFunction = dynamic_cast<SphericalHarmonicsFunction*>(scene.getSimpleGeometry()))
-                {
-                    sphericalHarmonicsFunction->update();
-                }
             }
-            else
+            else if(icosahedronGlitchParametersChanged)
+            {
+                geometry.create();
+            }
+
+            if(doUpdateCallSufficient)
             {
                 geometry.update();
             }
@@ -223,6 +227,7 @@ int main(int argc, char* argv[])
             scene.update();
 
             sceneNeedsUpdate = false;
+            icosahedronGlitchParametersChanged = false;
             newLevel.reset();
         }
 
@@ -263,7 +268,6 @@ int main(int argc, char* argv[])
 
             ImGui::SeparatorText("Scene specific parameters");
 
-          #if 0 // Disable Icosahedron glitch UI until update/create issue is fixed
             if(auto icosahedron = dynamic_cast<Icosahedron*>(scene.getSimpleGeometry()))
             {
                 float x = globals.animate ? globals.t : icosahedron->getPlatonicConstantsX();
@@ -282,10 +286,10 @@ int main(int argc, char* argv[])
                 || !fuzzy_equal(z, icosahedron->getPlatonicConstantsZ()) )
                 {
                     icosahedron->setPlatonicConstants(x, z);
+                    icosahedronGlitchParametersChanged = true;
                     sceneNeedsUpdate = true;
                 }
             }
-          #endif
             
             if(auto superquadric = dynamic_cast<Superquadric*>(scene.getSimpleGeometry()))
             {


### PR DESCRIPTION
- Verified that Icosahedron faces are oriented consistently counter-clockwise (CCW)
- Add `SimpleGeometry::unifyVertices()` that merges duplicate vertices brute-force
- Add `SimpleGeometry::computeFaceNormalsAndAdjacency()` that does
    - compute face normals via cross product, assuming consistent CCW winding and
    - creates a vertex-to-face adjacency map
- Add `SimpleGeometry::recomputeVertexNormals()` that computes vertex normals by averaging face normals, utilizing the previous vertex-to-face adjacency map
- Fix some update and UI issues; though some duplicate computations might remain